### PR TITLE
Changes related to FFTS in template matching to speed up both CPU and…

### DIFF
--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -417,6 +417,13 @@ inline bool DoesFileExistWithWait(wxString filename, int max_wait_time_in_second
 
 }
 
+// Function to check if x is power of 2
+inline bool is_power_of_two(int n)
+{
+   if(n==0) return false;
+   return (ceil(log2((float)n)) == floor(log2((float)n)));
+}
+
 inline float rad_2_deg(float radians)
 {
   return radians / (PIf / 180.);

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -152,6 +152,7 @@ public:
 	void RotateFourier2D(Image &rotated_image, AnglesAndShifts &rotation_angle, float resolution_limit_in_reciprocal_pixels = 1.0, bool use_nearest_neighbor = false);
 	void Rotate2D(Image &rotated_image, AnglesAndShifts &rotation_angle, float mask_radius_in_pixels = 0.0);
 	void Rotate2DInPlace(float rotation_in_degrees, float mask_radius_in_pixels = 0.0);
+	void Rotate2DInPlaceBy90Degrees(bool rotate_by_positive_90 = true);
 	void Rotate2DSample(Image &rotated_image, AnglesAndShifts &rotation_angle, float mask_radius_in_pixels = 0.0);
 	float Skew2D(Image &skewed_image, float height_offset, float minimum_height, float skew_axis, float skew_angle, bool adjust_signal = false);
 	float ReturnLinearInterpolated2D(float &wanted_physical_x_coordinate, float &wanted_physical_y_coordinate);

--- a/src/programs/make_template_result/make_template_result.cpp
+++ b/src/programs/make_template_result/make_template_result.cpp
@@ -40,6 +40,7 @@ void MakeTemplateResult::DoInteractiveUserInput()
 	int mip_x_dimension = 0;
 	int mip_y_dimension = 0;
 	bool read_coordinates;
+	int ignore_N_pixels_from_the_border = -1;
 
 	UserInput *my_input = new UserInput("MakeTemplateResult", 1.00);
 
@@ -69,11 +70,13 @@ void MakeTemplateResult::DoInteractiveUserInput()
 	slab_thickness = my_input->GetFloatFromUser("Sample thickness (A)", "The thickness of the sample that was searched", "2000.0", 100.0);
 	pixel_size = my_input->GetFloatFromUser("Pixel size of images (A)", "Pixel size of input images in Angstroms", "1.0", 0.0);
 	binning_factor = my_input->GetFloatFromUser("Binning factor for slab", "Factor to reduce size of output slab", "4.0", 0.0);
+	ignore_N_pixels_from_the_border = my_input->GetIntFromUser("Ignore N pixels from the edge of the MIP","Defaults to 1/2 the template dimension (-1)","-1",-1);
+
 
 	delete my_input;
 
 //	my_current_job.Reset(14);
-	my_current_job.ManualSetArguments("ttttttttttfffffbiii",	input_reconstruction_filename.ToUTF8().data(),
+	my_current_job.ManualSetArguments("ttttttttttfffffbiiii",	input_reconstruction_filename.ToUTF8().data(),
 													input_mip_filename.ToUTF8().data(),
 													input_best_psi_filename.ToUTF8().data(),
 													input_best_theta_filename.ToUTF8().data(),
@@ -89,7 +92,8 @@ void MakeTemplateResult::DoInteractiveUserInput()
 													pixel_size, binning_factor,
 													read_coordinates,
 													mip_x_dimension, mip_y_dimension,
-													result_number);
+													result_number,
+													ignore_N_pixels_from_the_border);
 }
 
 // override the do calculation method which will be what is actually run..
@@ -118,12 +122,14 @@ bool MakeTemplateResult::DoCalculation()
 	int 		mip_x_dimension = my_current_job.arguments[16].ReturnIntegerArgument();
 	int 		mip_y_dimension = my_current_job.arguments[17].ReturnIntegerArgument();
 	int 		result_number = my_current_job.arguments[18].ReturnIntegerArgument();
+	int 		ignore_N_pixels_from_the_border = my_current_job.arguments[19].ReturnIntegerArgument();
 
 	float padding = 2.0f;
 
 	ImageFile input_reconstruction_file;
 
 	input_reconstruction_file.OpenFile(input_reconstruction_filename.ToStdString(), false);
+
 
 	Image output_image;
 	Image mip_image;
@@ -179,6 +185,19 @@ bool MakeTemplateResult::DoCalculation()
 		min_peak_radius = powf(min_peak_radius, 2);
 	}
 
+	if (ignore_N_pixels_from_the_border > 0 && (ignore_N_pixels_from_the_border > mip_image.logical_x_dimension/2 || ignore_N_pixels_from_the_border > mip_image.logical_y_dimension/2))
+	{
+		wxPrintf("You have entered %d for ignore_N_pixels_from_the_border, which is too large given image half dimesnsions of %d (X) and %d (Y)",
+				ignore_N_pixels_from_the_border,mip_x_dimension/2, mip_y_dimension/2);
+		exit(-1);
+	}
+	if (ignore_N_pixels_from_the_border < 0)
+	{
+		// Default value is -1 giving
+		ignore_N_pixels_from_the_border = input_reconstruction_file.ReturnXSize() / 2 + 1;
+		// Otherwise, the user has asked for a specific value. Only available from the CLI.
+	}
+
 	output_image.Allocate(mip_x_dimension, mip_y_dimension, 1);
 	output_image.SetToConstant(0.0f);
 
@@ -229,7 +248,7 @@ bool MakeTemplateResult::DoCalculation()
 		{
 			// look for a peak..
 
-			current_peak = mip_image.FindPeakWithIntegerCoordinates(0.0, FLT_MAX, input_reconstruction_file.ReturnXSize() / 2 + 1);
+			current_peak = mip_image.FindPeakWithIntegerCoordinates(0.0, FLT_MAX, ignore_N_pixels_from_the_border);
 			if (current_peak.value < wanted_threshold) break;
 
 			// ok we have peak..


### PR DESCRIPTION
This commit has two primary functions:

1) Speed up FFTs when the image is rectangular.
2) Add option to specify border size in make_template_results. (Only affects CLI)

Details in commit message below.

Changes related to FFTS in template matching to speed up both CPU and…GPU code,

as well as make_template_results to add option to vary the border width.

match_template.cpp:
  * Found a general result that impacts rectangular FFTs for both MKL and cuFFT
    * If one dimension is a better factorization it should be along the primary
      image dimension (x) as the speedup in an FFT is apparently more pronounced
      in this way. For a K3 image, which pads out to 5832 4096 in nice size,
      this means the image should be rotated by 90.
        * CPU speed up = 97% runtime
        * GPU speed up = 86% runtime

functions.h:
  * add a simple function to check whether or not a number is a power of two.
    Hopefully I didn't miss something that a was already there.

image.cpp
  * add a method that quickly rotates an image +/- 90 with no interpolation. It
    is possible that RotateQuadrants could have worked, as the real space portion
    has basically the same block. There are actually duplicate checks on whether
    the image is square (isSquare()) and (is logical_x == logical_y). For the new method
    IT MUST WORK WITH NON SQUARE images. Happy to modify the existing method, but
    I didn't want to mess with it.

make_template_results:
  * Add a new option to modify the default behavior that ignores peaks that are
    NX_template/2 from the edge. Take an integer value in pixels. This will
    break any scripts that run this program.