### PR TITLE
Initialize xyz_offset to 0.0 and suprress c++11 warnings from (gpu) t…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -168,6 +168,9 @@ AC_ARG_WITH([cuda], AS_HELP_STRING([--with-cuda@<:@=yes|no|DIR@:>@], [prefix whe
 if test "$want_cuda" = "yes" 
 then
 
+	# In Thrust 1.10 c++11 is deprecated. Not using those libs now, so squash warnings, but we should consider switching to a newer standard
+	AC_DEFINE(THRUST_IGNORE_DEPRECATED_CPP_11,true)
+
 	# Set conditional and run macro	
 	AX_CUDA
 	

--- a/src/programs/align_coordinates/align_coordinates.cpp
+++ b/src/programs/align_coordinates/align_coordinates.cpp
@@ -97,9 +97,9 @@ bool AlignCoordinatesApp::DoCalculation()
 	int theta_i, number_of_theta_angles;
 	int phi_i, number_of_phi_angles;
 	float best_x, best_y;
-	float xyz_offset[3];
-	float ref_center_of_mass[3];
-	float align_center_of_mass[3];
+	float xyz_offset[3] = {0.0f,0.0f,0.0f};
+	float ref_center_of_mass[3] = {0.0f,0.0f,0.0f};
+	float align_center_of_mass[3] = {0.0f,0.0f,0.0f};
 	float anchor_align_x, anchor_align_y;
 	float anchor_ref_x, anchor_ref_y;
 	float std_x = 0.0f, std_y = 0.0f, std_z = 0.0f;


### PR DESCRIPTION
…hrust library.

This resolves #233 

@ngrigorieff I think you were making some changes to align_coordinates to add optional borders. Please incorporate this fix so that you can verify it doesn't create any surprises for you.