### PR TITLE
Relion motioncor export

### DIFF
--- a/src/gui/ExportRefinementPackageWizard.cpp
+++ b/src/gui/ExportRefinementPackageWizard.cpp
@@ -280,6 +280,8 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 		wxString micrograph_filename;
 		float original_movie_pixel_size;
 
+		int random_subset;
+
 		RefinementPackageParticleInfo current_particle;
 		RefinementResult current_refinement_result;
 		ImageAsset * current_image_asset;
@@ -413,10 +415,11 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 			relion_star_file->AddLine(wxString("_rlnOriginXAngst #17"));
 			relion_star_file->AddLine(wxString("_rlnOriginYAngst #18"));
 			relion_star_file->AddLine(wxString("_rlnOpticsGroup #19"));
+			relion_star_file->AddLine(wxString("_rlnRandomSubset #20"));
 
 
 			relion_corrected_micrographs_file->AddLine(wxString(" "));
-			relion_corrected_micrographs_file->AddLine(wxString("data_microgaphs"));
+			relion_corrected_micrographs_file->AddLine(wxString("data_micrographs"));
 			relion_corrected_micrographs_file->AddLine(wxString(" "));
 			relion_corrected_micrographs_file->AddLine(wxString("loop_"));
 			relion_corrected_micrographs_file->AddLine(wxString("_rlnMicrographName #1"));
@@ -498,7 +501,14 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 			else
 			if(Relion3RadioButton->GetValue() == true)
 			{
-				relion_star_file->AddLine(wxString::Format("%s %f %f %06li@%s %f %f %f %f %f %f %f %f %f %f %f %f %f %f %i",	micrograph_filename,
+				/*
+				 * We will write even-odd distribution of particles into half maps, but 
+				 * in fact cisTEM, does not do it that way (each process divides its stack into 100 and
+				 * alternates between them). However this is irrelevant since cisTEM does not do 
+				 * independent half-dataset refinements anyway.
+				 */
+				if (random_subset == 2) { random_subset = 1; } else { random_subset = 2; }
+				relion_star_file->AddLine(wxString::Format("%s %f %f %06li@%s %f %f %f %f %f %f %f %f %f %f %f %f %f %f %i %i",	micrograph_filename,
 																							current_particle.x_pos / current_particle.pixel_size,
 																							current_particle.y_pos / current_particle.pixel_size,
 																							particle_counter + 1,
@@ -517,7 +527,8 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 																							current_refinement_result.psi,
 																							-current_refinement_result.xshift,
 																							-current_refinement_result.yshift,
-																							1));
+																							1,
+																							random_subset));
 			
 				if (current_particle_is_first_from_this_image)
 				{

--- a/src/gui/ExportRefinementPackageWizard.cpp
+++ b/src/gui/ExportRefinementPackageWizard.cpp
@@ -569,8 +569,13 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 					{
 						should_continue = main_frame->current_project.database.GetFromBatchSelect("iss", &frame_counter, &current_x_shift, &current_y_shift);
 						if (frame_counter == 1) { first_x_shift = current_x_shift; first_y_shift = current_y_shift; }
-						// Relion expects shifts to be in pixels, but unblur returns them in Angstroms
-						relion_motioncor_star_current_file->AddLine(wxString::Format("%i %f %f", frame_counter, (current_x_shift-first_x_shift)/float(current_image_asset->pixel_size), (current_y_shift-first_y_shift)/float(current_image_asset->pixel_size)));
+						/* 
+						 * Relion expects shifts to be in pixels, but unblur returns them in Angstroms
+						 * Specifically, Relion expects them in the original input movie pixels before binning 
+						 * even with --early_binning. For EER, it depends on --eer_upsampling. If it is 2, 
+						 * it is 8K pixels (= 2x superresolution), if 1, it is 4K pixels (= hardware pixels)
+						 */
+						relion_motioncor_star_current_file->AddLine(wxString::Format("%i %f %f", frame_counter, (current_x_shift-first_x_shift)/float(current_movie_asset->pixel_size), (current_y_shift-first_y_shift)/float(current_movie_asset->pixel_size)));
 					}
 					main_frame->current_project.database.EndBatchSelect();
 

--- a/src/gui/ExportRefinementPackageWizard.cpp
+++ b/src/gui/ExportRefinementPackageWizard.cpp
@@ -522,6 +522,10 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 			
 				if (current_particle_is_first_from_this_image)
 				{
+					// We will need a star file to store results of motion correction
+					relion_motioncor_star_current_filename.SetPath(relion_motioncor_star_base_filename.GetPath());
+					relion_motioncor_star_current_filename.SetName(wxString::Format("%s_%06i.star",relion_motioncor_star_base_filename.GetName(),current_image_asset->asset_id));
+
 					// Add this micrograph to the star file listing all micrographs
 					relion_corrected_micrographs_file->AddLine(wxString::Format("%s %s %i",micrograph_filename.ToStdString(),relion_motioncor_star_current_filename.GetFullPath(),1));
 
@@ -536,8 +540,6 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 					/*
 					 * Write out a star file with the results of the whole-frame motion correction
 					 */
-					relion_motioncor_star_current_filename.SetPath(relion_motioncor_star_base_filename.GetPath());
-					relion_motioncor_star_current_filename.SetName(wxString::Format("%s_%06i.star",relion_motioncor_star_base_filename.GetName(),current_image_asset->asset_id));
 					relion_motioncor_star_current_file = new wxTextFile(relion_motioncor_star_current_filename.GetFullPath());
 					if (relion_motioncor_star_current_file->Exists())
 					{

--- a/src/gui/ExportRefinementPackageWizard.cpp
+++ b/src/gui/ExportRefinementPackageWizard.cpp
@@ -252,11 +252,23 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 	if (RelionRadioButton->GetValue() == true || Relion3RadioButton->GetValue() == true) 
 	{
 		wxFileName output_stack_filename = ParticleStackFileTextCtrl->GetLineText(0);
-		wxFileName relion_star_filename = MetaDataFileTextCtrl->GetLineText(0);
+		wxFileName relion_star_filename = MetaDataFileTextCtrl->GetLineText(0); // one line per particle
+		wxFileName relion_corrected_micrographs_filename = MetaDataFileTextCtrl->GetLineText(0); // one line per motion-corrected movie
+		wxFileName relion_motioncor_star_base_filename = MetaDataFileTextCtrl->GetLineText(0); // one star file per movie, with one line per frame
+		wxFileName relion_motioncor_star_current_filename;
 
 		relion_star_filename.SetExt("star");
+		relion_corrected_micrographs_filename.ClearExt();
+		relion_corrected_micrographs_filename.SetName( relion_corrected_micrographs_filename.GetName() + wxT("_corrected_micrographs.star"));
+		relion_motioncor_star_base_filename.ClearExt();
+		relion_motioncor_star_base_filename.SetName( relion_motioncor_star_base_filename.GetName() + wxT("_motioncorr"));
 
 		wxTextFile *relion_star_file = new wxTextFile(relion_star_filename.GetFullPath());
+		wxTextFile *relion_corrected_micrographs_file = new wxTextFile(relion_corrected_micrographs_filename.GetFullPath());
+		wxTextFile *relion_motioncor_star_current_file;
+
+		wxArrayInt array_of_unique_parent_image_asset_ids;
+		bool current_particle_is_first_from_this_image;
 
 		MRCFile input_stack(current_package->stack_filename.ToStdString(), false);
 		MRCFile output_stack(output_stack_filename.GetFullPath().ToStdString(), true);
@@ -266,9 +278,12 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 		double particle_radius = current_package->estimated_particle_size_in_angstroms / 2;
 
 		wxString micrograph_filename;
+		float original_movie_pixel_size;
 
 		RefinementPackageParticleInfo current_particle;
 		RefinementResult current_refinement_result;
+		ImageAsset * current_image_asset;
+		MovieAsset * current_movie_asset;
 
 		if (relion_star_file->Exists())
 		{
@@ -278,6 +293,16 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 		else
 		{
 			relion_star_file->Create();
+		}
+
+		if (relion_corrected_micrographs_file->Exists())
+		{
+			relion_corrected_micrographs_file->Open();
+			relion_corrected_micrographs_file->Clear();
+		}
+		else
+		{
+			relion_corrected_micrographs_file->Create();
 		}
 
 		//write optics data block for relion3.1 format
@@ -296,10 +321,13 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 			relion_star_file->AddLine(wxString("_rlnImageSize #7"));
 			relion_star_file->AddLine(wxString("_rlnImageDimensionality #8"));
 
-			//Currently I am only using the first particle to get infomration for the optics groups, 
+			//Currently I am only using the first particle to get information for the optics groups, 
 			//this will cause issues if datasets are merged together with different microscopy parameters
 			RefinementPackageParticleInfo first_particle;
 			first_particle = current_package->ReturnParticleInfoByPositionInStack(1);
+			MyDebugAssertTrue(first_particle.parent_image_id >= 0,"Oops. Invalid parent image ID for the first particle");
+			current_image_asset = image_asset_panel->ReturnAssetPointer(image_asset_panel->ReturnArrayPositionFromAssetID(first_particle.parent_image_id));
+			current_movie_asset = movie_asset_panel->ReturnAssetPointer(movie_asset_panel->ReturnArrayPositionFromAssetID(current_image_asset->parent_id));
 			
 			relion_star_file->AddLine(wxString::Format("%i %s %f %f %f %f %i %i",	1,
 																	"opticsGroup1",
@@ -310,6 +338,27 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 																	current_package->stack_box_size,
 																	2
 																	));
+
+
+			// The corrected micrographs star file
+			relion_corrected_micrographs_file->AddLine(wxString(" "));
+			relion_corrected_micrographs_file->AddLine(wxString("data_optics"));
+			relion_corrected_micrographs_file->AddLine(wxString(" "));
+			relion_corrected_micrographs_file->AddLine(wxString("loop_"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnOpticsGroupName #1"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnOpticsGroup #2"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnMicrographOriginalPixelSize #3"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnVoltage #4"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnSphericalAberration #5"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnAmplitudeContrast #6"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnMicrographPixelSize #7"));
+
+			relion_corrected_micrographs_file->AddLine(wxString::Format("%s %i %f %f %f %f %f", "opticsGroup1", 1,
+																								current_movie_asset->pixel_size,
+																								first_particle.microscope_voltage,
+																								first_particle.spherical_aberration,
+																								first_particle.amplitude_contrast,
+																								current_image_asset->pixel_size));
 		}
 
 		//write particle data block for either relion2 or relion3.1 format
@@ -364,6 +413,15 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 			relion_star_file->AddLine(wxString("_rlnOriginXAngst #17"));
 			relion_star_file->AddLine(wxString("_rlnOriginYAngst #18"));
 			relion_star_file->AddLine(wxString("_rlnOpticsGroup #19"));
+
+
+			relion_corrected_micrographs_file->AddLine(wxString(" "));
+			relion_corrected_micrographs_file->AddLine(wxString("data_microgaphs"));
+			relion_corrected_micrographs_file->AddLine(wxString(" "));
+			relion_corrected_micrographs_file->AddLine(wxString("loop_"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnMicrographName #1"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnMicrographMetadata #2"));
+			relion_corrected_micrographs_file->AddLine(wxString("_rlnOpticsGroup #3"));
 		}
 
 		OneSecondProgressDialog *my_dialog = new OneSecondProgressDialog ("Export To Relion", "Exporting...", current_package->contained_particles.GetCount(), this);
@@ -373,13 +431,37 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 		{
 			current_particle = current_package->ReturnParticleInfoByPositionInStack(particle_counter + 1);
 			current_refinement_result = current_refinement->ReturnRefinementResultByClassAndPositionInStack(ClassComboBox->GetSelection(), particle_counter + 1);
+			current_image_asset = image_asset_panel->ReturnAssetPointer(image_asset_panel->ReturnArrayPositionFromAssetID(current_particle.parent_image_id));
+			current_movie_asset = movie_asset_panel->ReturnAssetPointer(movie_asset_panel->ReturnArrayPositionFromAssetID(current_image_asset->parent_id));
+			
+			// Check whether we have already written out the motioncor results for the parent image asset. If not, 
+			current_particle_is_first_from_this_image = (particle_counter == 0) || (array_of_unique_parent_image_asset_ids.Index(current_particle.parent_image_id,true) == wxNOT_FOUND);
+			if (current_particle_is_first_from_this_image)
+			{
+				//wxPrintf("Particle %li, from image asset %li. If you see this more than once per image asset, there is a bug.\n",particle_counter,current_particle.parent_image_id);
+				array_of_unique_parent_image_asset_ids.Add(int(current_particle.parent_image_id));
+
+				relion_motioncor_star_current_filename.SetPath(relion_motioncor_star_base_filename.GetPath());
+				relion_motioncor_star_current_filename.SetName(wxString::Format("%s_%06i.star",relion_motioncor_star_base_filename.GetName(),current_image_asset->asset_id));
+				relion_motioncor_star_current_file = new wxTextFile(relion_motioncor_star_current_filename.GetFullPath());
+				if (relion_motioncor_star_current_file->Exists())
+				{
+					relion_motioncor_star_current_file->Open();
+					relion_motioncor_star_current_file->Clear();
+				}
+				else
+				{
+					relion_motioncor_star_current_file->Create();
+				}
+			}
+			
 
 			particle_image.ReadSlice(&input_stack, particle_counter + 1);
 			if (current_package->stack_has_white_protein == false) particle_image.InvertRealValues();
 			particle_image.ZeroFloatAndNormalize(1.0, particle_radius /current_particle.pixel_size, true);
 			particle_image.WriteSlice(&output_stack, particle_counter + 1);
 
-			// if we have micrograph info, may aswell include it..
+			// if we have micrograph info, may as well include it..
 
 			if (current_particle.parent_image_id >= 0)
 			{
@@ -436,20 +518,85 @@ void ExportRefinementPackageWizard::OnFinished(  wxWizardEvent& event  )
 																							-current_refinement_result.xshift,
 																							-current_refinement_result.yshift,
 																							1));
-			}
-			else
+			
+				if (current_particle_is_first_from_this_image)
+				{
+					relion_corrected_micrographs_file->AddLine(wxString::Format("%s %s %i",micrograph_filename.ToStdString(),relion_motioncor_star_current_filename.GetFullPath(),1));
+
+					// Let's grab the motion correction job details from the database
+					bool should_continue = main_frame->current_project.database.BeginBatchSelect(wxString::Format("SELECT PRE_EXPOSURE_AMOUNT,FIRST_FRAME_TO_SUM FROM MOVIE_ALIGNMENT_LIST WHERE MOVIE_ASSET_ID=%i AND ALIGNMENT_ID=%i", current_movie_asset->asset_id, current_image_asset->alignment_id));
+					if (!should_continue) { MyPrintWithDetails("Error getting information about movie alignment!"); DEBUG_ABORT; }
+					float pre_exposure_amount;
+					int first_frame_to_sum;
+					main_frame->current_project.database.GetFromBatchSelect("si", &pre_exposure_amount, &first_frame_to_sum);
+					main_frame->current_project.database.EndBatchSelect();
+
+
+					// Write out a star file with the results of the whole-frame motion correction
+					relion_motioncor_star_current_file->AddLine(wxString(" "));
+					relion_motioncor_star_current_file->AddLine(wxString("data_general"));
+					relion_motioncor_star_current_file->AddLine(wxString(" "));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %i","_rlnImageSizeX",current_movie_asset->x_size));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %i","_rlnImageSizeY",current_movie_asset->y_size));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %i","_rlnImageSizeZ",current_movie_asset->number_of_frames));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %s","_rlnMicrographMovieName",current_movie_asset->filename.GetFullPath()));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %s","_rlnMicrographGainName",current_movie_asset->gain_filename.ToStdString()));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %f","_rlnMicrographBinning",current_movie_asset->output_binning_factor));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %f","_rlnMicrographOriginalPixelSize",current_movie_asset->pixel_size));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %f","_rlnMicrographDoseRate",current_movie_asset->dose_per_frame));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %f","_rlnMicrographPreExposure",pre_exposure_amount));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %f","_rlnMicrographVoltage",current_movie_asset->microscope_voltage));
+					relion_motioncor_star_current_file->AddLine(wxString::Format("%s %i","_rlnMicrographStartFrame",first_frame_to_sum));
+
+					// Write out the section with the whole-frame shifts
+					relion_motioncor_star_current_file->AddLine(wxString(" "));
+					relion_motioncor_star_current_file->AddLine(wxString("data_global_shift"));
+					relion_motioncor_star_current_file->AddLine(wxString(" "));
+					relion_motioncor_star_current_file->AddLine(wxString("loop_"));
+					relion_motioncor_star_current_file->AddLine(wxString("_rlnMicrographFrameNumber #1"));
+					relion_motioncor_star_current_file->AddLine(wxString("_rlnMicrographShiftX #2"));
+					relion_motioncor_star_current_file->AddLine(wxString("_rlnMicrographShiftY #3"));
+
+					// Grab the actual alignment results from the database
+					should_continue = main_frame->current_project.database.BeginBatchSelect(wxString::Format("SELECT * FROM MOVIE_ALIGNMENT_PARAMETERS_%i", current_image_asset->alignment_id));
+					int frame_counter;
+					float current_x_shift;
+					float current_y_shift;
+					float first_x_shift;
+					float first_y_shift;
+					if (!should_continue) { MyPrintWithDetails("Error getting alignment result!"); DEBUG_ABORT; }
+					while (should_continue)
+					{
+						should_continue = main_frame->current_project.database.GetFromBatchSelect("iss", &frame_counter, &current_x_shift, &current_y_shift);
+						if (frame_counter == 1) { first_x_shift = current_x_shift; first_y_shift = current_y_shift; }
+						// Relion expects shifts to be in pixels, but unblur returns them in Angstroms
+						relion_motioncor_star_current_file->AddLine(wxString::Format("%i %f %f", frame_counter, (current_x_shift-first_x_shift)/float(current_image_asset->pixel_size), (current_y_shift-first_y_shift)/float(current_image_asset->pixel_size)));
+					}
+					main_frame->current_project.database.EndBatchSelect();
+
+					relion_motioncor_star_current_file->Write();
+					relion_motioncor_star_current_file->Close();
+					delete relion_motioncor_star_current_file;
+				} // first particle from this image
+				
+			} // relion3
 
 			my_dialog->Update(particle_counter+1);
-		}
+		} // loop over particles
 
 		relion_star_file->Write();
 		relion_star_file->Close();
+
+		relion_corrected_micrographs_file->Write();
+		relion_corrected_micrographs_file->Close();
 
 		input_stack.CloseFile();
 		output_stack.CloseFile();
 
 		delete relion_star_file	;
 		delete current_refinement;
+
+		delete relion_corrected_micrographs_file;
 
 		my_dialog->Destroy();
 	}


### PR DESCRIPTION
When the user exports a refinement package to Relion 3.1, these changes mean that they will also end up with the star files necessary to enable Polishing in Relion: a star file that lists all micrographs and one per micrographs that includes whole-frame alignment parameters.

Note: for now, particles are assigned to half-datasets using even/odd particles, which is not how cisTEM actually assigns particles to the half maps. This means that upon re-importing a polished stack into cisTEM, the FSC may show strong overfitting artefacts (I think because Polishing uses the full frequency spectrum for alignments and relies on "gold-standard" half-dataset particle assignments). This will be fixed in a future pull request. For now, the solution is to run e.g. an auto refinement starting at 20Å to alleviate any overfitting.