### PR TITLE
Mkl debug for amd cpus

### DIFF
--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -1303,3 +1303,158 @@ bool StripEnclosingSingleQuotesFromString(wxString &string_to_strip)
 	else return false;
 
 }
+
+///////////////////////////// CPU CHECK /////////////////
+
+//  The intel MKL is hobbled on AMD processors, the purpose of this section of code is to detect if we are running on an AMD processor that can
+//  use advanced features of the MKL, and if we are then to set a debug environment variable which significantly improves performance.
+
+#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1300)
+#include <immintrin.h>
+
+int check_4th_gen_intel_core_features()
+{
+    const int the_4th_gen_features =
+        (_FEATURE_AVX2 | _FEATURE_FMA | _FEATURE_BMI | _FEATURE_LZCNT | _FEATURE_MOVBE);
+    return _may_i_use_cpu_feature( the_4th_gen_features );
+}
+
+#else /* non-Intel compiler */
+
+#include <stdint.h>
+#if defined(_MSC_VER)
+# include <intrin.h>
+#endif
+
+
+void run_cpuid(uint32_t eax, uint32_t ecx, uint32_t* abcd)
+{
+#if defined(_MSC_VER)
+    __cpuidex(abcd, eax, ecx);
+#else
+    uint32_t ebx, edx;
+# if defined( __i386__ ) && defined ( __PIC__ )
+     /* in case of PIC under 32-bit EBX cannot be clobbered */
+    __asm__ ( "movl %%ebx, %%edi \n\t cpuid \n\t xchgl %%ebx, %%edi" : "=D" (ebx),
+# else
+    __asm__ ( "cpuid" : "+b" (ebx),
+# endif
+              "+a" (eax), "+c" (ecx), "=d" (edx) );
+    abcd[0] = eax; abcd[1] = ebx; abcd[2] = ecx; abcd[3] = edx;
+#endif
+}
+
+int check_xcr0_ymm()
+{
+    uint32_t xcr0;
+#if defined(_MSC_VER)
+    xcr0 = (uint32_t)_xgetbv(0);  /* min VS2010 SP1 compiler is required */
+#else
+    __asm__ ("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx" );
+#endif
+    return ((xcr0 & 6) == 6); /* checking if xmm and ymm state are enabled in XCR0 */
+}
+
+
+int check_4th_gen_intel_core_features()
+{
+    uint32_t abcd[4];
+    uint32_t fma_movbe_osxsave_mask = ((1 << 12) | (1 << 22) | (1 << 27));
+    uint32_t avx2_bmi12_mask = (1 << 5) | (1 << 3) | (1 << 8);
+
+    /* CPUID.(EAX=01H, ECX=0H):ECX.FMA[bit 12]==1   &&
+       CPUID.(EAX=01H, ECX=0H):ECX.MOVBE[bit 22]==1 &&
+       CPUID.(EAX=01H, ECX=0H):ECX.OSXSAVE[bit 27]==1 */
+    run_cpuid( 1, 0, abcd );
+    if ( (abcd[2] & fma_movbe_osxsave_mask) != fma_movbe_osxsave_mask )
+        return 0;
+
+    if ( ! check_xcr0_ymm() )
+        return 0;
+
+    /*  CPUID.(EAX=07H, ECX=0H):EBX.AVX2[bit 5]==1  &&
+        CPUID.(EAX=07H, ECX=0H):EBX.BMI1[bit 3]==1  &&
+        CPUID.(EAX=07H, ECX=0H):EBX.BMI2[bit 8]==1  */
+    run_cpuid( 7, 0, abcd );
+    if ( (abcd[1] & avx2_bmi12_mask) != avx2_bmi12_mask )
+        return 0;
+
+    /* CPUID.(EAX=80000001H):ECX.LZCNT[bit 5]==1 */
+    run_cpuid( 0x80000001, 0, abcd );
+    if ( (abcd[2] & (1 << 5)) == 0)
+        return 0;
+
+    return 1;
+}
+
+#endif /* non-Intel compiler */
+
+static int can_use_intel_core_4th_gen_features()
+{
+    static int the_4th_gen_features_available = -1;
+    /* test is performed once */
+    if (the_4th_gen_features_available < 0 )
+        the_4th_gen_features_available = check_4th_gen_intel_core_features();
+
+    return the_4th_gen_features_available;
+}
+
+#include <cpuid.h>
+
+void ActivateMKLDebugForNonIntelCPU() // this sets an environment variable that should speed up recent AMD cpus when using MKL significantly
+{
+#ifdef MKL // Only do something if using MKL..
+
+	// Get the vendor string, as if it has INTEL in it, we won't do anything..
+
+	char CPUBrandString[0x40];
+	unsigned int CPUInfo[4] = {0,0,0,0};
+
+	__cpuid(0x80000000, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+	unsigned int nExIds = CPUInfo[0];
+
+	memset(CPUBrandString, 0, sizeof(CPUBrandString));
+
+	for (unsigned int i = 0x80000000; i <= nExIds; ++i)
+	{
+	    __cpuid(i, CPUInfo[0], CPUInfo[1], CPUInfo[2], CPUInfo[3]);
+
+	    if (i == 0x80000002)
+	        memcpy(CPUBrandString, CPUInfo, sizeof(CPUInfo));
+	    else if (i == 0x80000003)
+	        memcpy(CPUBrandString + 16, CPUInfo, sizeof(CPUInfo));
+	    else if (i == 0x80000004)
+	        memcpy(CPUBrandString + 32, CPUInfo, sizeof(CPUInfo));
+	}
+
+	wxString CPUBrandWXString = CPUBrandString;
+	wxString CPUBrandWXString_Lowercase = CPUBrandString;
+	CPUBrandWXString_Lowercase.MakeLower();
+	CPUBrandWXString.Trim(true);
+	CPUBrandWXString.Trim(false);
+
+
+	bool is_an_intel_cpu;
+
+	if (CPUBrandWXString_Lowercase.Find("intel") != wxNOT_FOUND) is_an_intel_cpu = true;
+	else is_an_intel_cpu = false;
+
+	if (is_an_intel_cpu == true) {MyDebugPrint("CPU is INTEL (%s)\n", CPUBrandWXString);}
+	else MyDebugPrint("CPU is not INTEL (%s)\n", CPUBrandWXString);
+
+
+	// if we aren't an Intel CPU do a basic feature check, if it passes then set environment variable
+
+	if (is_an_intel_cpu == false)
+	{
+		if ( can_use_intel_core_4th_gen_features() )
+		{
+			MyDebugPrint("This CPU supports ISA extensions introduced in Haswell\n");
+			MyDebugPrint("Setting MKL_DEBUG_CPU_TYPE=5 Environment variable\n");
+			wxSetEnv("MKL_DEBUG_CPU_TYPE", "5");
+		}
+		else
+			MyDebugPrint("This CPU does not support all ISA extensions introduced in Haswell\n");
+	}
+#endif
+}

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -38,6 +38,7 @@ inline void ZeroFloatArray(float *array_to_zero, int size_of_array)
 	}
 }
 
+
 void FirstLastParticleForJob(long &first_particle, long &last_particle, long number_of_particles, int current_job_number, int number_of_jobs );
 
 int ReturnSafeBinnedBoxSize(int original_box_size, float bin_factor);
@@ -599,3 +600,5 @@ double cisTEM_erfinv(double x);
 double cisTEM_erfcinv(double x);
 
 bool StripEnclosingSingleQuotesFromString(wxString &string_to_strip); // returns true if it was done, false if first and last characters are not '
+
+void ActivateMKLDebugForNonIntelCPU(); // will activate MKL debug environment variable if running on an AMD that supports high level features.  This works on my version on intel MKL - it is disabled in the released MKL (although setting it should not break anything)

--- a/src/core/myapp.cpp
+++ b/src/core/myapp.cpp
@@ -45,6 +45,7 @@ bool MyApp::OnInit()
 
 	inter_thread_message_queue.Post(0);
 
+	ActivateMKLDebugForNonIntelCPU(); // if not Intel CPU and if using the MKL attempt to set an environment variable that can lead to substanstial speedup.
 	ProgramSpecificInit();
 
 	return true;

--- a/src/core/refinement.cpp
+++ b/src/core/refinement.cpp
@@ -765,3 +765,20 @@ void Refinement::SetAllAmplitudeContrast(float wanted_amplitude_contrast)
 
 }
 
+void Refinement::SetAssignedSubsetToEvenOdd()
+{
+	int class_counter;
+	int particle_counter;
+
+
+	for (class_counter = 0; class_counter < this->number_of_classes; class_counter++)
+	{
+		for (particle_counter = 0; particle_counter < this->number_of_particles; particle_counter++)
+		{
+			if (IsEven(particle_counter) == true) this->class_refinement_results[class_counter].particle_refinement_results[particle_counter].assigned_subset = 1;
+			else
+			this->class_refinement_results[class_counter].particle_refinement_results[particle_counter].assigned_subset = 2;
+		}
+	}
+}
+

--- a/src/core/refinement.cpp
+++ b/src/core/refinement.cpp
@@ -353,7 +353,8 @@ void Refinement::WriteSingleClasscisTEMStarFile(wxString filename,int wanted_cla
 	FrealignParameterFile *my_output_par_file = new FrealignParameterFile(filename, OPEN_TO_WRITE);
 
 	cisTEMParameters output_params;
-	output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK | IMAGE_IS_ACTIVE | PSI | THETA | PHI | X_SHIFT | Y_SHIFT | DEFOCUS_1 | DEFOCUS_2 | DEFOCUS_ANGLE | PHASE_SHIFT | OCCUPANCY | LOGP | SIGMA | SCORE | SCORE_CHANGE | PIXEL_SIZE | MICROSCOPE_VOLTAGE | MICROSCOPE_CS | AMPLITUDE_CONTRAST | BEAM_TILT_X | BEAM_TILT_Y | IMAGE_SHIFT_X | IMAGE_SHIFT_Y | STACK_FILENAME | ORIGINAL_IMAGE_FILENAME | REFERENCE_3D_FILENAME | BEST_2D_CLASS | BEAM_TILT_GROUP | PARTICLE_GROUP | PRE_EXPOSURE | TOTAL_EXPOSURE | ASSIGNED_SUBSET);
+	output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK | IMAGE_IS_ACTIVE | PSI | THETA | PHI | X_SHIFT | Y_SHIFT | DEFOCUS_1 | DEFOCUS_2 | DEFOCUS_ANGLE | PHASE_SHIFT | OCCUPANCY | LOGP | SIGMA | SCORE | PIXEL_SIZE | MICROSCOPE_VOLTAGE | MICROSCOPE_CS | AMPLITUDE_CONTRAST | BEAM_TILT_X | BEAM_TILT_Y | IMAGE_SHIFT_X | IMAGE_SHIFT_Y | ASSIGNED_SUBSET);
+
 	output_params.PreallocateMemoryAndBlank(number_of_particles);
 
 	for ( particle_counter = 0; particle_counter < number_of_particles; particle_counter++)

--- a/src/core/refinement.h
+++ b/src/core/refinement.h
@@ -135,6 +135,7 @@ public :
 	void SetAllVoltages(float wanted_voltage_in_kV);
 	void SetAllCs(float wanted_Cs_in_mm);
 	void SetAllAmplitudeContrast(float wanted_amplitude_contrast);
+	void SetAssignedSubsetToEvenOdd();
 
 
 };

--- a/src/gui/AbInitio3DPanel.cpp
+++ b/src/gui/AbInitio3DPanel.cpp
@@ -2647,6 +2647,7 @@ void AbInitioManager::ProcessAllJobsFinished()
 		input_refinement->SetAllVoltages(300);
 		input_refinement->SetAllCs(2.7);
 		input_refinement->SetAllAmplitudeContrast(0.07);
+		input_refinement->SetAssignedSubsetToEvenOdd();
 
 
 		SetupReconstructionJob();


### PR DESCRIPTION
This is basically some cpu detection functions to look for AMD cpus in combination with MKL. if found, it will set an environment variable which will in some cases speed things up by 50% or more as per https://cistem.org/potential-speedup-mkl-operations-amd-ryzenthreadripperepyc