### PR TITLE
A few bug fixes

### DIFF
--- a/src/core/refinement.cpp
+++ b/src/core/refinement.cpp
@@ -350,8 +350,6 @@ void Refinement::WriteSingleClasscisTEMStarFile(wxString filename,int wanted_cla
 	long particle_counter;
 	float temp_float;
 
-	FrealignParameterFile *my_output_par_file = new FrealignParameterFile(filename, OPEN_TO_WRITE);
-
 	cisTEMParameters output_params;
 	output_params.parameters_to_write.SetActiveParameters(POSITION_IN_STACK | IMAGE_IS_ACTIVE | PSI | THETA | PHI | X_SHIFT | Y_SHIFT | DEFOCUS_1 | DEFOCUS_2 | DEFOCUS_ANGLE | PHASE_SHIFT | OCCUPANCY | LOGP | SIGMA | SCORE | PIXEL_SIZE | MICROSCOPE_VOLTAGE | MICROSCOPE_CS | AMPLITUDE_CONTRAST | BEAM_TILT_X | BEAM_TILT_Y | IMAGE_SHIFT_X | IMAGE_SHIFT_Y | ASSIGNED_SUBSET);
 

--- a/src/gui/AbInitio3DPanel.cpp
+++ b/src/gui/AbInitio3DPanel.cpp
@@ -2644,10 +2644,14 @@ void AbInitioManager::ProcessAllJobsFinished()
 		input_refinement->resolution_statistics_pixel_size = active_pixel_size;
 		input_refinement->resolution_statistics_box_size = check_file.ReturnXSize();
 		input_refinement->SetAllPixelSizes(active_pixel_size);
-		input_refinement->SetAllVoltages(300);
-		input_refinement->SetAllCs(2.7);
-		input_refinement->SetAllAmplitudeContrast(0.07);
-		input_refinement->SetAssignedSubsetToEvenOdd();
+
+		if (active_use_classums == true) // in this case input refinement and output refinement should be the same
+		{
+			input_refinement->SetAllVoltages(300);
+			input_refinement->SetAllCs(2.7);
+			input_refinement->SetAllAmplitudeContrast(0.07);
+			input_refinement->SetAssignedSubsetToEvenOdd();
+		}
 
 
 		SetupReconstructionJob();

--- a/src/gui/MyRefine2DPanel.cpp
+++ b/src/gui/MyRefine2DPanel.cpp
@@ -807,20 +807,6 @@ void ClassificationManager::RunInitialStartJob()
 
 	my_parent->SetNumberConnectedTextToZeroAndStartTracking();
 
-	WriteClassificationStarFileThread *star_file_writer_thread;
-	star_file_writer_thread = new WriteClassificationStarFileThread(my_parent, main_frame->current_project.parameter_file_directory.GetFullPath() + "/classification_input_star", output_classification, active_refinement_package);
-
-	if ( star_file_writer_thread->Run() != wxTHREAD_NO_ERROR )
-	{
-		my_parent->WriteErrorText("Error: Cannot start star file writer thread, things are going to break...");
-		delete star_file_writer_thread;
-	}
-}
-
-
-
-void ClassificationManager::RunInitialStartJobPostStarFileWrite(wxString input_star_file)
-{
 	number_of_received_particle_results = 0;
 
 	output_classification->classification_id = main_frame->current_project.database.ReturnHighestClassificationID() + 1;
@@ -863,6 +849,22 @@ void ClassificationManager::RunInitialStartJobPostStarFileWrite(wxString input_s
 		output_classification->classification_results[counter - 1].defocus_angle = active_refinement_package->ReturnParticleInfoByPositionInStack( counter ).defocus_angle;
 		output_classification->classification_results[counter - 1].phase_shift = active_refinement_package->ReturnParticleInfoByPositionInStack( counter ).phase_shift;
 	}
+
+
+	WriteClassificationStarFileThread *star_file_writer_thread;
+	star_file_writer_thread = new WriteClassificationStarFileThread(my_parent, main_frame->current_project.parameter_file_directory.GetFullPath() + "/classification_input_star", output_classification, active_refinement_package);
+
+	if ( star_file_writer_thread->Run() != wxTHREAD_NO_ERROR )
+	{
+		my_parent->WriteErrorText("Error: Cannot start star file writer thread, things are going to break...");
+		delete star_file_writer_thread;
+	}
+}
+
+
+
+void ClassificationManager::RunInitialStartJobPostStarFileWrite(wxString input_star_file)
+{
 
 	wxString input_particle_images =  active_refinement_package->stack_filename;
 	wxString input_class_averages = "/dev/null";

--- a/src/programs/refine2d/refine2d.cpp
+++ b/src/programs/refine2d/refine2d.cpp
@@ -812,12 +812,14 @@ bool Refine2DApp::DoCalculation()
 							current_block_read_size = 0;
 						}
 					}
+					else
+					{
+						current_block_read_size++;
+						if (current_block_read_size == block_size) keep_reading = false;
 
-					current_block_read_size++;
-					if (current_block_read_size == block_size) keep_reading = false;
-
-					input_image_local.ReadSlice(&input_stack, input_parameters.position_in_stack);
-					file_read = true;
+						input_image_local.ReadSlice(&input_stack, input_parameters.position_in_stack);
+						file_read = true;
+					}
 				}
 			}
 


### PR DESCRIPTION
1.  The particle normalisation for refine2d was missing an else, which
meant that all the particles were being used for power spectum
calculation.  This is very slow with 3 million particles!

2. WriteSingleClasscisTEMStarFile was declaring a FrealignParameterFile
object which was never used.

3. In the ab-inito, the Voltage and Cs was always being set to 300 /
2.7, this should only have been done when class averages are the input.

4. When running the initial start job for 2D classification, the binary
star file was being written before the parameters were set leading to a
blank file.