### PR TITLE
EER support in unblur and ctffind

### DIFF
--- a/src/core/eer_file.cpp
+++ b/src/core/eer_file.cpp
@@ -207,7 +207,7 @@ void EerFile::ReadSlicesFromDisk(int start_slice, int end_slice, float *output_a
 
 		start_pos_in_output_array = (slice_counter-start_slice) * (logical_dimension_x*logical_dimension_y*super_res_factor*super_res_factor);
 
-		MyDebugPrint("Reading slice %i of %i (EER frames %i to %i)",slice_counter,end_slice - start_slice +1, start_eer_frame,finish_eer_frame);
+		MyDebugPrint("Reading slice %i of %i (EER frames %i to %i)",slice_counter,number_of_images, start_eer_frame,finish_eer_frame);
 		DecodeToFloatArray(start_eer_frame,finish_eer_frame,&output_array[start_pos_in_output_array]);
 	}
 

--- a/src/core/eer_file.cpp
+++ b/src/core/eer_file.cpp
@@ -96,6 +96,7 @@ bool EerFile::ReadLogicalDimensionsFromDisk(bool check_only_the_first_image)
 {
 	MyDebugAssertTrue(tif != NULL,"File must be open");
 	MyDebugAssertTrue(fh != NULL,"File must be open");
+	MyDebugAssertFalse(number_of_eer_frames_per_image == 0, "Number of EER frames per image has not yet been set. Cannot work out logical dimensions.");
 	/*
 	 * Since the file was already open, EerOpen has already read in the first dictionary
 	 * and it must be valid, else we would have returned an error at open-time already
@@ -207,7 +208,7 @@ void EerFile::ReadSlicesFromDisk(int start_slice, int end_slice, float *output_a
 
 		start_pos_in_output_array = (slice_counter-start_slice) * (logical_dimension_x*logical_dimension_y*super_res_factor*super_res_factor);
 
-		MyDebugPrint("Reading slice %i of %i (EER frames %i to %i)",slice_counter,number_of_images, start_eer_frame,finish_eer_frame);
+		//MyDebugPrint("Reading slice %i of %i (EER frames %i to %i)",slice_counter,number_of_images, start_eer_frame,finish_eer_frame);
 		DecodeToFloatArray(start_eer_frame,finish_eer_frame,&output_array[start_pos_in_output_array]);
 	}
 

--- a/src/core/functions.cpp
+++ b/src/core/functions.cpp
@@ -504,6 +504,14 @@ wxString ReturnIPAddressFromSocket(wxSocketBase *socket)
 
 }
 
+// Test whether the filename's extension matches; case insensitive
+bool FilenameExtensionMatches(std::string filename, std::string extension)
+{
+	wxFileName input_filename_wx(filename);
+	wxString input_filename_ext = input_filename_wx.GetExt();
+	return input_filename_ext.IsSameAs(extension,false);
+}
+
 /*
  *
  * String manipulations

--- a/src/core/functions.h
+++ b/src/core/functions.h
@@ -528,6 +528,8 @@ float CalculateAngularStep(float required_resolution, float radius_in_angstroms)
 int ReturnClosestFactorizedUpper(int wanted_int, int largest_factor, bool enforce_even = false, int enforce_factor = 0);
 int ReturnClosestFactorizedLower(int wanted_int, int largest_factor, bool enforce_even = false, int enforce_factor = 0);
 
+bool FilenameExtensionMatches(std::string filename, std::string extension);
+
 /*
  *
  * String manipulations

--- a/src/core/image_file.cpp
+++ b/src/core/image_file.cpp
@@ -89,7 +89,7 @@ void ImageFile::ReadSlicesFromDisk(int start_slice, int end_slice, float *output
 	case TIFF_FILE: tiff_file.ReadSlicesFromDisk(start_slice, end_slice, output_array); break;
 	case MRC_FILE: mrc_file.ReadSlicesFromDisk(start_slice, end_slice, output_array); break;
 	case DM_FILE: dm_file.ReadSlicesFromDisk(start_slice-1, end_slice-1, output_array); break;
-	case EER_FILE: eer_file.ReadSlicesFromDisk(start_slice-1, end_slice-1, output_array); break;
+	case EER_FILE: eer_file.ReadSlicesFromDisk(start_slice, end_slice, output_array); break;
 	default: MyPrintWithDetails("Unsupported file type\n"); DEBUG_ABORT; break;
 	}
 }

--- a/src/gui/AlignMoviesPanel.cpp
+++ b/src/gui/AlignMoviesPanel.cpp
@@ -517,6 +517,7 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 	int first_frame;
 	int last_frame;
 
+	int eer_frames_per_image;
 	int number_of_frames_for_running_average;
 	int max_threads;
 
@@ -711,6 +712,7 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 		mag_distortion_minor_axis_scale = movie_asset_panel->ReturnMagDistortionMinorScale(active_group.members[counter]);
 
 
+		eer_frames_per_image = 0;
 		number_of_frames_for_running_average = 1;
 		max_threads = 1;
 
@@ -718,7 +720,7 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 		std::string aligned_frames_filename = "/dev/null";
 		std::string output_shift_text_file = "/dev/null";
 
-		current_job_package.AddJob("ssfffbbfifbiifffbsbsfbfffbtbtiiiibtt",current_filename.c_str(), //0
+		current_job_package.AddJob("ssfffbbfifbiifffbsbsfbfffbtbtiiiibtti",current_filename.c_str(), //0
 														output_filename.ToUTF8().data(),
 														current_pixel_size,
 														float(minimum_shift),
@@ -753,7 +755,8 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 														max_threads,
 														saved_aligned_frames,
 														aligned_frames_filename.c_str(),
-														output_shift_text_file.c_str());
+														output_shift_text_file.c_str(),
+														eer_frames_per_image);
 
 		my_progress_dialog->Update(counter + 1);
 	}

--- a/src/gui/AlignMoviesPanel.cpp
+++ b/src/gui/AlignMoviesPanel.cpp
@@ -563,6 +563,8 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 	float mag_distortion_major_axis_scale;
 	float mag_distortion_minor_axis_scale;
 
+	const int eer_frames_per_image = 0;
+
 
 	// read the options form the gui..
 
@@ -712,7 +714,6 @@ void MyAlignMoviesPanel::StartAlignmentClick( wxCommandEvent& event )
 		mag_distortion_minor_axis_scale = movie_asset_panel->ReturnMagDistortionMinorScale(active_group.members[counter]);
 
 
-		eer_frames_per_image = 0;
 		number_of_frames_for_running_average = 1;
 		max_threads = 1;
 

--- a/src/gui/FindCTFPanel.cpp
+++ b/src/gui/FindCTFPanel.cpp
@@ -600,6 +600,7 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 
 	bool determine_tilt;
 
+	const int eer_frames_per_image = 0;
 
 	// allocate space for the buffered results..
 
@@ -752,7 +753,7 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 
 		const int number_of_threads = 1;
 
-		current_job_package.AddJob("sbisffffifffffbfbfffbffbbsbsbfffbfffbi",	input_filename.c_str(), // 0
+		current_job_package.AddJob("sbisffffifffffbfbfffbffbbsbsbfffbfffbii",	input_filename.c_str(), // 0
 																	input_is_a_movie, // 1
 																	number_of_frames_to_average, //2
 																	output_diagnostic_filename.c_str(), // 3
@@ -789,7 +790,8 @@ void MyFindCTFPanel::StartEstimationClick( wxCommandEvent& event )
 																	known_defocus_2,
 																	known_phase_shift,
 																	determine_tilt,
-																	number_of_threads);
+																	number_of_threads,
+																	eer_frames_per_image);
 
 		my_progress_dialog->Update(counter + 1);
 	}

--- a/src/programs/unblur/unblur.cpp
+++ b/src/programs/unblur/unblur.cpp
@@ -131,12 +131,11 @@ void UnBlurApp::DoInteractiveUserInput()
 	 		 aligned_frames_filename = "";
 	 	 }
 		
-		wxFileName input_filename_wx(input_filename);
-		wxString input_filename_ext = input_filename_wx.GetExt();
-		if (input_filename_ext.IsSameAs("eer",false))
+		if (FilenameExtensionMatches(input_filename,"eer"))
 		{
 			eer_frames_per_image = my_input->GetIntFromUser("Number of EER frames per image","If the input movie is in EER format, we will average EER frames together so that each frame image for alignment has a reasonable exposure","25",1);
 		}
+		else { eer_frames_per_image = 0; }
 	 }
  	 else
  	 {

--- a/src/programs/unblur/unblur.cpp
+++ b/src/programs/unblur/unblur.cpp
@@ -55,6 +55,7 @@ void UnBlurApp::DoInteractiveUserInput()
 	int last_frame;
 	int number_of_frames_for_running_average;
 	int max_threads;
+	int eer_frames_per_image = 0;
 
 	bool save_aligned_frames;
 
@@ -129,7 +130,14 @@ void UnBlurApp::DoInteractiveUserInput()
 	 	 {
 	 		 aligned_frames_filename = "";
 	 	 }
- 	 }
+		
+		wxFileName input_filename_wx(input_filename);
+		wxString input_filename_ext = input_filename_wx.GetExt();
+		if (input_filename_ext.IsSameAs("eer",false))
+		{
+			eer_frames_per_image = my_input->GetIntFromUser("Number of EER frames per image","If the input movie is in EER format, we will average EER frames together so that each frame image for alignment has a reasonable exposure","25",1);
+		}
+	 }
  	 else
  	 {
  		 minimum_shift_in_angstroms = original_pixel_size * output_binning_factor + 0.001;
@@ -149,7 +157,7 @@ void UnBlurApp::DoInteractiveUserInput()
  		 number_of_frames_for_running_average = 1;
  		 save_aligned_frames = false;
  		 aligned_frames_filename = "";
-
+		 eer_frames_per_image = 0;
  	 }
 
 	correct_mag_distortion = my_input->GetYesNoFromUser("Correct Magnification Distortion?", "If yes, a magnification distortion can be corrected", "no");
@@ -181,8 +189,8 @@ void UnBlurApp::DoInteractiveUserInput()
 	bool write_out_small_sum_image = false;
 	std::string small_sum_image_filename = "/dev/null";
 
-	my_current_job.Reset(36);
-	my_current_job.ManualSetArguments("ttfffbbfifbiifffbsbsfbfffbtbtiiiibtt",input_filename.c_str(),
+	my_current_job.Reset(37);
+	my_current_job.ManualSetArguments("ttfffbbfifbiifffbsbsfbfffbtbtiiiibtti",input_filename.c_str(),
 																 output_filename.c_str(),
 																 original_pixel_size,
 																 minimum_shift_in_angstroms,
@@ -217,7 +225,8 @@ void UnBlurApp::DoInteractiveUserInput()
 																 max_threads,
 																 save_aligned_frames,
 																 aligned_frames_filename.c_str(),
-																 output_shift_text_file.c_str());
+																 output_shift_text_file.c_str(),
+																 eer_frames_per_image);
 
 
 }
@@ -278,6 +287,7 @@ bool UnBlurApp::DoCalculation()
 	bool		saved_aligned_frames				= my_current_job.arguments[33].ReturnBoolArgument();
 	std::string aligned_frames_filename 			= my_current_job.arguments[34].ReturnStringArgument();
 	std::string output_shift_text_file				= my_current_job.arguments[35].ReturnStringArgument();
+	int			eer_frames_per_image				= my_current_job.arguments[36].ReturnIntegerArgument();
 
 	if (is_running_locally == false) max_threads = number_of_threads_requested_on_command_line; // OVERRIDE FOR THE GUI, AS IT HAS TO BE SET ON THE COMMAND LINE...
 
@@ -307,7 +317,7 @@ bool UnBlurApp::DoCalculation()
 		exit(-1);
 	}
 	ImageFile input_file;
-	bool input_file_is_valid = input_file.OpenFile(input_filename, false);
+	bool input_file_is_valid = input_file.OpenFile(input_filename, false,false,false,1,eer_frames_per_image);
 	if (!input_file_is_valid)
 	{
 		SendInfo(wxString::Format("Input movie %s seems to be corrupt. Unblur results may not be meaningful.\n", input_filename));


### PR DESCRIPTION
This adds support for EER-format frame stacks as inputs to `unblur` and `ctffind` on the command line